### PR TITLE
refactor: replace crypto crates with encryptman v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "encryptman"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4550441d80c8d91226403ab385279a264338d71ff155006576707e595d0d85d0"
+dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
+ "hkdf",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "zeroize",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4579,16 +4593,12 @@ dependencies = [
 name = "tb-database"
 version = "1.3.0"
 dependencies = [
- "aes-gcm",
  "anyhow",
- "base64 0.22.1",
  "chrono",
- "hkdf",
- "rand",
+ "encryptman",
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.11.0",
  "sqlx",
  "tb-models",
  "tempfile",
@@ -6134,6 +6144,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/tb-database/Cargo.toml
+++ b/crates/tb-database/Cargo.toml
@@ -17,11 +17,7 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
-aes-gcm = "0.10"
-hkdf = "0.13"
-sha2 = "0.11"
-rand = "0.10"
-base64 = "0.22"
+encryptman = "0.2.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tb-database/src/settings/crypto.rs
+++ b/crates/tb-database/src/settings/crypto.rs
@@ -1,57 +1,16 @@
-use aes_gcm::aead::rand_core::RngCore;
-use aes_gcm::aead::{Aead, KeyInit, OsRng};
-use aes_gcm::{Aes256Gcm, Key, Nonce};
-use anyhow::{Context, Result};
-use base64::Engine;
-use hkdf::Hkdf;
-use sha2::Sha256;
+use anyhow::Result;
+use encryptman::MasterKey;
 
-const KEY_SIZE: usize = 32;
-const NONCE_SIZE: usize = 12;
-const CONTEXT: &str = "tb-plus-settings-v1";
+pub use encryptman::generate_master_key;
 
-pub fn generate_master_key() -> [u8; KEY_SIZE] {
-  let mut key = [0u8; KEY_SIZE];
-  OsRng.fill_bytes(&mut key);
-  key
+pub fn encrypt(master_key: &MasterKey, plaintext: &str) -> Result<String> {
+  encryptman::encrypt(master_key, plaintext)
+    .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
-fn derive_key(master_key: &[u8; KEY_SIZE]) -> Key<Aes256Gcm> {
-  let hk = Hkdf::<Sha256>::new(None, master_key);
-  let mut okm = [0u8; KEY_SIZE];
-  hk.expand(CONTEXT.as_bytes(), &mut okm)
-    .expect("HKDF expand should succeed");
-  *Key::<Aes256Gcm>::from_slice(&okm)
-}
-
-pub fn encrypt(master_key: &[u8; KEY_SIZE], plaintext: &str) -> Result<String> {
-  let key = derive_key(master_key);
-  let cipher = Aes256Gcm::new(&key);
-  let mut nonce_bytes = [0u8; NONCE_SIZE];
-  OsRng.fill_bytes(&mut nonce_bytes);
-  let nonce = Nonce::from_slice(&nonce_bytes);
-  let ciphertext = cipher
-    .encrypt(nonce, plaintext.as_bytes())
-    .map_err(|e| anyhow::anyhow!("encryption failed: {e}"))?;
-  let mut packed = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
-  packed.extend_from_slice(&nonce_bytes);
-  packed.extend_from_slice(&ciphertext);
-  Ok(base64::engine::general_purpose::STANDARD.encode(&packed))
-}
-
-pub fn decrypt(master_key: &[u8; KEY_SIZE], encoded: &str) -> Result<String> {
-  let key = derive_key(master_key);
-  let cipher = Aes256Gcm::new(&key);
-  let packed = base64::engine::general_purpose::STANDARD
-    .decode(encoded)
-    .context("invalid base64")?;
-  anyhow::ensure!(packed.len() > NONCE_SIZE, "ciphertext too short");
-  let (nonce_bytes, ciphertext) = packed.split_at(NONCE_SIZE);
-  let nonce = Nonce::from_slice(nonce_bytes);
-  let plaintext = cipher
-    .decrypt(nonce, ciphertext)
-    .map_err(|_| anyhow::anyhow!("decryption failed"))?;
-  String::from_utf8(plaintext).context("decrypted data is not valid UTF-8")
+pub fn decrypt(master_key: &MasterKey, encoded: &str) -> Result<String> {
+  encryptman::decrypt(master_key, encoded)
+    .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 #[cfg(test)]

--- a/crates/tb-database/src/settings/mod.rs
+++ b/crates/tb-database/src/settings/mod.rs
@@ -2,6 +2,7 @@ pub mod crypto;
 
 use anyhow::Result;
 use chrono::Local;
+use encryptman::MasterKey;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use sqlx::SqlitePool;
@@ -15,7 +16,7 @@ const KEY_FILENAME: &str = ".tb_key";
 
 pub struct SettingsManager {
   pool: SqlitePool,
-  master_key: [u8; 32],
+  master_key: MasterKey,
 }
 
 #[allow(dead_code)]
@@ -28,28 +29,28 @@ impl SettingsManager {
     Ok(mgr)
   }
 
-  pub fn master_key(&self) -> &[u8; 32] {
+  pub fn master_key(&self) -> &MasterKey {
     &self.master_key
   }
 
   // ── Key management ────────────────────────────────────────────────────────
 
-  fn load_or_create_key(app_data_dir: &std::path::Path) -> [u8; 32] {
+  fn load_or_create_key(app_data_dir: &std::path::Path) -> MasterKey {
     Self::load_or_create_static_key(app_data_dir)
   }
 
-  pub fn load_or_create_static_key(app_data_dir: &std::path::Path) -> [u8; 32] {
+  pub fn load_or_create_static_key(app_data_dir: &std::path::Path) -> MasterKey {
     let key_path = app_data_dir.join(KEY_FILENAME);
     if key_path.exists() {
       let raw = std::fs::read(&key_path).unwrap_or_default();
       if raw.len() == 32 {
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&raw);
-        return key;
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(&raw);
+        return MasterKey::from_bytes(bytes);
       }
     }
     let key = crypto::generate_master_key();
-    let _ = std::fs::write(&key_path, key);
+    let _ = std::fs::write(&key_path, key.as_bytes());
     key
   }
 


### PR DESCRIPTION
## Summary

Replace 5 direct crypto dependencies (`aes-gcm`, `hkdf`, `sha2`, `rand`, `base64`) with the `encryptman` crate v0.2.0, which bundles them internally under a safe, high-level API.

## Changes

- **Cargo.toml**: Remove 5 deps, add `encryptman = "0.2.0"`
- **crypto.rs**: Rewrite to delegate to `encryptman::encrypt` / `encryptman::decrypt` (57 lines -> 16 lines)
- **mod.rs**: `SettingsManager.master_key` field type changes from `[u8; 32]` to `encryptman::MasterKey`

## Motivation

`encryptman` provides the same AES-256-GCM + HKDF-SHA256 pipeline with:
- `MasterKey` struct with automatic zeroize-on-drop
- Versioned ciphertext format
- `CryptoError` enum instead of raw `anyhow` strings
- Same battle-tested crypto crates under the hood

## Verification

- `cargo check -p tb-database` -- clean (0 warnings)
- `cargo test -p tb-database` -- all 45 tests pass
